### PR TITLE
Revert base imaget to ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04
+FROM ubuntu:18.04
 
 MAINTAINER Yusuke KOMORI <komo@littleforest.jp>
 


### PR DESCRIPTION
Ubuntu 23.04 din't work well because `ubuntu` used (uid=1000) exists.